### PR TITLE
Feature/fix double proptypes prefix generation

### DIFF
--- a/examples/proptypes-openapi.js
+++ b/examples/proptypes-openapi.js
@@ -36,14 +36,14 @@ export const AnObjectPropTypes = {
 export const NewsTeaserPropTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
-	link: PropTypes.PropTypes.shape(LinkPropTypes),
-	img: PropTypes.PropTypes.shape(ImgPropTypes),
+	link: PropTypes.shape(LinkPropTypes),
+	img: PropTypes.shape(ImgPropTypes),
 };
 
 export const FooterPropTypes = {
 	title: PropTypes.string.isRequired,
 	websiteDescription: PropTypes.string.isRequired,
-	logo: PropTypes.PropTypes.shape(ImgPropTypes).isRequired,
+	logo: PropTypes.shape(ImgPropTypes).isRequired,
 	copyright: PropTypes.string,
 	footerLinks: PropTypes.arrayOf(PropTypes.shape(LinkPropTypes)),
 	':type': PropTypes.string,

--- a/examples/proptypes-swagger.js
+++ b/examples/proptypes-swagger.js
@@ -36,13 +36,13 @@ export const AnObjectPropTypes = {
 export const NewsTeaserPropTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
-	link: PropTypes.PropTypes.shape(LinkPropTypes),
-	img: PropTypes.PropTypes.shape(ImgPropTypes),
+	link: PropTypes.shape(LinkPropTypes),
+	img: PropTypes.shape(ImgPropTypes),
 };
 
 export const NewsTeaserListPropTypes = {
 	newsTeaserList: PropTypes.arrayOf(
-		PropTypes.PropTypes.shape(NewsTeaserPropTypes),
+		PropTypes.shape(NewsTeaserPropTypes),
 		PropTypes.shape({
 			leadText: PropTypes.string,
 		}),
@@ -52,7 +52,7 @@ export const NewsTeaserListPropTypes = {
 export const FooterPropTypes = {
 	title: PropTypes.string.isRequired,
 	websiteDescription: PropTypes.string.isRequired,
-	logo: PropTypes.PropTypes.shape(ImgPropTypes).isRequired,
+	logo: PropTypes.shape(ImgPropTypes).isRequired,
 	copyright: PropTypes.string,
 	footerLinks: PropTypes.arrayOf(PropTypes.shape(LinkPropTypes)),
 	':type': PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi-proptypes-generator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Generate PropTypes from openAPI 3 schemas",
   "main": "src/schemaToPropTypes.js",
   "scripts": {

--- a/src/schemaToPropTypes.js
+++ b/src/schemaToPropTypes.js
@@ -60,9 +60,10 @@ const getRef = ref => ref.split('/').pop();
  * Creates the string for the value of a property.
  * @param {String} propertyName - The key (name) of the property.
  * @param {Object} property - The property to generate the value from.
+ * @param {Boolean} prefixReturn - Add Proptypes Prefix to return.
  * @returns {string}
  */
-const getPropTypeValue = (propertyName, property) => {
+const getPropTypeValue = (propertyName, property, prefixReturn = true) => {
 	let propType = ``;
 
 	switch (property.type) {
@@ -114,7 +115,7 @@ const getPropTypeValue = (propertyName, property) => {
 			break;
 	}
 
-	return `PropTypes.${propType}`;
+	return `${prefixReturn ? 'PropTypes.' : ''}${propType}`;
 };
 
 /**
@@ -127,7 +128,7 @@ const getPropTypeValueFromUntyped = (propertyName, property) => {
 	let propType = ``;
 
 	if (property.$ref) {
-		propType = getPropTypeValue(propertyName, { type: 'object', ...property });
+		propType = getPropTypeValue(propertyName, { type: 'object', ...property }, false);
 	} else if (property.allOf) {
 		propType += 'arrayOf(';
 		property.allOf.forEach(item => {


### PR DESCRIPTION
This PR fixes a bug where

```
"newsTeaser": {
    "type": "object",
    "properties": {
        "link": {
            "$ref": "#/definitions/link"
```

would create
```
export const NewsTeaserPropTypes = {
	link: PropTypes.PropTypes.shape(LinkPropTypes),
};
```

This double `PropTypes.` Prefix creation was related to a double call of the `getPropTypeValue` Function - which had a fixed
```
return `PropTypes.${propType}`;
```

As you can see in proptypes-swagger / openapi.js File the double prefix is now gone.