### PR TITLE
feat: emit oneOf for enums

### DIFF
--- a/src/schemaToPropTypes.js
+++ b/src/schemaToPropTypes.js
@@ -66,6 +66,12 @@ const getRef = ref => ref.split('/').pop();
 const getPropTypeValue = (propertyName, property, prefixReturn = true) => {
 	let propType = ``;
 
+	if (typeof property.enum !== 'undefined') {
+		const items = JSON.stringify(property.enum);
+		propType += `oneOf(${items})`;
+		return `${prefixReturn ? 'PropTypes.' : ''}${propType}`;
+	}
+
 	switch (property.type) {
 		case 'array':
 			if (property.items.$ref) {


### PR DESCRIPTION
With this change, enums are converted to oneOf propTypes, instead of
being emitted as string.

This is a breaking change, as its stricter than before.

Given a definition like this:

```json
"attribute": {
  "type": "string",
  "enum": [
    "hidden",
    "shown"
  ]
}
```

Before:

```js
PropTypes.string.isRequired
```

After:

```js
PropTypes.oneOf(["hidden","shown"]).isRequired
```

Formatting of these files could be improved, but didn't want to touch too many things at once.