### PR TITLE
Fix empty object generation if type object has no properties

### DIFF
--- a/examples/proptypes-swagger.js
+++ b/examples/proptypes-swagger.js
@@ -27,6 +27,8 @@ export const AnObjectPropTypes = {
 	}),
 };
 
+export const EmptyObjectPropTypes = {};
+
 export const NewsTeaserPropTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,

--- a/examples/swagger.json
+++ b/examples/swagger.json
@@ -79,6 +79,9 @@
         }
       }
     },
+    "emptyObject": {
+      "type": "object"
+    },
     "newsTeaser": {
       "type": "object",
       "properties": {

--- a/src/schemaToPropTypes.js
+++ b/src/schemaToPropTypes.js
@@ -238,9 +238,11 @@ const getPropTypes = (schemaName, schema) => {
 		isObjectDefinition,
 	);
 	const reducer = propertiesReducer(schema.properties, requiredProps, isObjectDefinition);
+	const reduceSchemaProperties =
+		schema.properties && Object.keys(schema.properties).reduce(reducer, '');
 
-	return schema.type === 'object'
-		? Object.keys(schema.properties).reduce(reducer, '')
+	return isObjectDefinition
+		? reduceSchemaProperties
 		: propTypeStringIndented([schemaName, schema, requiredProps, isObjectDefinition]);
 };
 
@@ -254,10 +256,16 @@ const getPropTypes = (schemaName, schema) => {
 const schemasReducer = (str, [schemaName, schema]) => {
 	const componentName = formatComponentName(schemaName);
 	const isObjectDefinition = schema.type === 'object';
+	const hasProperties = !!schema.properties;
 	const propTypes = getPropTypes(schemaName, schema);
 
 	if (isObjectDefinition) {
-		return `${str}\nexport const ${componentName} = {\n${propTypes}};\n`;
+		if (hasProperties) {
+			return `${str}\nexport const ${componentName} = {\n${propTypes}};\n`;
+		}
+
+		// return empty object if type object has no properties
+		return `${str}\nexport const ${componentName} = {};\n`;
 	}
 
 	return `${str}\nexport const ${componentName} = ${propTypes};\n`;


### PR DESCRIPTION
This PR will fix the failing PropTypes generation if an empty Object is added.

I added a check inside `getPropTypes` to check if the schema has properties and if not we will not return anything - this fix the error message
```
TypeError: Cannot convert undefined or null to object
```

Second I updated `schemasReducer` to return `{}` when the schema doesn't have properties.
This is added for explicity.

So this code:
```
"emptyObject": {
    "type": "object"
},
```

will result in:
```
export const EmptyObjectPropTypes = {};
```